### PR TITLE
Fix a minor oversight, and add additional support info

### DIFF
--- a/srfi-245.html
+++ b/srfi-245.html
@@ -94,11 +94,13 @@ expr_5</code></pre>
 
 <h2 id="implementation">Implementation</h2>
 
-<p>Scheme implementations which already support this SRFI include MIT Scheme, Chicken, and Guile.
+<p>Scheme implementations which already support this SRFI include MIT Scheme, Chicken, Guile, Kawa, and S7.
 
 <h2 id="acknowledgements">Acknowledgements</h2>
 
 <p>Marc Nieper-Wißkirchen suggested this change.
+
+<p>William Gardner Schottstaedt let me know that S7 supported this SRFI, and Per Bothner that Kawa already supports it.
 
 <h2 id="copyright">Copyright</h2>
 <p>&copy; 2023 Daphne Preston-Kendal.</p>

--- a/srfi-245.html
+++ b/srfi-245.html
@@ -64,7 +64,7 @@
 
 <p>The final <em>expression</em> becomes the result of evaluating the <em>body</em>; it is in tail position if the body as a whole is in tail position.
 
-<p>It is an error for the evaluation of any expression or of the right-hand side of any definition in the sequence of <em>definition or expression</em>s to require knowledge of the value of a variable whose definition is to the right of it.
+<p>It is an error for the evaluation of any expression or of the right-hand side of any definition in the sequence of <em>definition or expression</em>s to use or assign the value of a variable whose definition is to the right of it.
 
 <p>It is an error to invoke the continuation of any variable definition more than once, either directly, or by returning again to the continuation of an expression which appears before a definition and then allowing control flow to continue back to the definition. Implementations are strongly encouraged to detect this situation and signal an error when it occurs.
 


### PR DESCRIPTION
One quick new draft before finalization, I hope.

One place has been changed to reflect what R7RS small says about assignment before definition as well as use before definition. I’ve also added the support info about S7 and Kawa.